### PR TITLE
Add Code of Conduct based on Contributor Covenant

### DIFF
--- a/content/code-of-conduct.md
+++ b/content/code-of-conduct.md
@@ -5,3 +5,78 @@ template = "base.html"
 +++
 
 # WWU CS Slack Community Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+members and administrators pledge to making participation in our community a
+harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Community administrators are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Community administrators have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any member for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within community spaces and in public spaces
+when an individual is representing the community. Examples of representing the
+community include using an official community e-mail address, posting via an
+official social media account, or acting as an appointed representative
+at an online or offline event. Representation of the community may be further
+defined and clarified by community administrators.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the [administrators][community-admins]. All complaints
+will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The administrators are
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
+
+Community administrators who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the community's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][document]
+
+[community-admins]: https://wwucs.slack.com/account/team
+[homepage]: https://www.contributor-covenant.org
+[document]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html


### PR DESCRIPTION
This is almost verbatim a copy of the [Contributor Covenant v1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) except that I've made the following replacements:
- `contributors` -> `members`
- `maintainers` -> `community administrators`
- `project` -> `community`

I've specifically avoided any additional language about academic dishonesty as we're still hashing that out as administrators.

To see **exactly** what I've changed compared to the Contributor Covenant feel free to review this diff:
```diff
--- content/code-of-conduct.md	2017-11-13 19:10:17.507813055 -0800
+++ /home/tucker/Downloads/code-of-conduct.md	2017-11-13 18:01:42.990923567 -0800
@@ -1,17 +1,11 @@
-+++
-title = "WWU CS Slack Code of Conduct"
-description = "WWU CS Slack Community Code of Conduct"
-template = "base.html"
-+++
-
-# WWU CS Slack Community Code of Conduct
+# Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-members and administrators pledge to making participation in our community a
-harassment-free experience for everyone, regardless of age, body size,
-disability, ethnicity, gender identity and expression, level of experience,
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
 nationality, personal appearance, race, religion, or sexual identity and
 orientation.
 
@@ -39,44 +33,42 @@
 
 ## Our Responsibilities
 
-Community administrators are responsible for clarifying the standards of acceptable
+Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Community administrators have the right and responsibility to remove, edit, or
+Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any member for other behaviors that they deem inappropriate,
+permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within community spaces and in public spaces
-when an individual is representing the community. Examples of representing the
-community include using an official community e-mail address, posting via an
-official social media account, or acting as an appointed representative
-at an online or offline event. Representation of the community may be further
-defined and clarified by community administrators.
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the [administrators][community-admins]. All complaints
-will be reviewed and investigated and will result in a response that is deemed
-necessary and appropriate to the circumstances. The administrators are
-obligated to maintain confidentiality with regard to the reporter of an
-incident. Further details of specific enforcement policies may be posted
-separately.
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
 
-Community administrators who do not follow or enforce the Code of Conduct in good
+Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
-members of the community's leadership.
+members of the project's leadership.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][document]
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
-[community-admins]: https://wwucs.slack.com/account/team
 [homepage]: https://www.contributor-covenant.org
-[document]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
```