### PR TITLE
Add Sass styling

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -1,0 +1,4 @@
+Some of the Sass styles used by this site borrow from the Contribtor Covenant,
+which is licensed under the Creative Commons Attribution 4.0 International
+Public License. The license can be found at
+https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE.md

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -1,0 +1,26 @@
+body {
+  margin: 1.5rem;
+  font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;
+  background-color: $base-background-color;
+}
+
+section {
+  max-width: 47rem;
+  margin: 0 auto;
+}
+
+a {
+  color: $link-color;
+  &:hover {
+    color: $link-hover-color;
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: $header-font-family;
+}
+
+#wwu-cs-slack-community, #wwu-cs-slack-community-code-of-conduct {
+  text-align: center;
+  text-transform: uppercase;
+}

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -29,3 +29,14 @@ h1, h2, h3, h4, h5, h6 {
   text-align: center;
   text-transform: uppercase;
 }
+
+@media (max-width: 640px) {
+  html {
+    font-size: 0.75rem;
+  }
+
+  body {
+    padding: 1.5rem 0;
+  }
+
+}

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -20,7 +20,12 @@ h1, h2, h3, h4, h5, h6 {
   font-family: $header-font-family;
 }
 
+* + h2 {
+    margin-top: 3rem;
+}
+
 #wwu-cs-slack-community, #wwu-cs-slack-community-code-of-conduct {
+  font-size: $header-font-size;
   text-align: center;
   text-transform: uppercase;
 }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,9 +1,10 @@
 $base-font-family: 'Garamond', serif;
-$header-font-family: 'Futura', sans-serif;
-
 $base-font-weight: 300;
 $base-font-size: .75rem;
 $base-line-height: 1.4rem;
+
+$header-font-family: 'Futura', sans-serif;
+$header-font-size:  1rem;
 
 $text-color: #333;
 $link-color: rgb(0, 63 ,135);

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,1 +1,13 @@
+$base-font-family: 'Garamond', serif;
+$header-font-family: 'Futura', sans-serif;
+
+$base-font-weight: 300;
+$base-font-size: .75rem;
+$base-line-height: 1.4rem;
+
+$text-color: #333;
+$link-color: rgb(0, 63 ,135);
+$link-hover-color: rgb(0, 131, 214);
+$base-background-color: rgb(255, 254, 248);
+
 @import "base";

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,12 +1,11 @@
 $base-font-family: 'Garamond', serif;
 $base-font-weight: 300;
-$base-font-size: .75rem;
-$base-line-height: 1.4rem;
+$base-font-size: 1.25rem;
+$base-line-height: 1.875rem;
 
 $header-font-family: 'Futura', sans-serif;
 $header-font-size:  1rem;
 
-$text-color: #333;
 $link-color: rgb(0, 63 ,135);
 $link-hover-color: rgb(0, 131, 214);
 $base-background-color: rgb(255, 254, 248);

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,8 +7,10 @@
     <link rel="stylesheet" href="{{ config.base_url | safe }}/main.css" />
   </head>
   <body>
+    <section>
     {% block content %}
       {{ page.content | safe }}
     {% endblock content %}
+    </section>
   </body>
 </html>


### PR DESCRIPTION
This adds Sass styles (which are automatically compiled by Gutenberg on build). They borrow from the Contributor Covenant's own CSS a little bit, especially in making the Code of Conduct render better on mobile devices.


Below are images of the differences between the current and proposed styling. The left-hand side is the current styling, the right-hand is with these new styles applied. Both are rendered in Firefox 57.0 on Fedora 27.

### Desktop
![wwucs-sass-styling-fullscreen](https://user-images.githubusercontent.com/3084059/32988149-a7b2086c-ccb2-11e7-8ed5-cbdd488220b8.png)

### Mobile
![wwucs-sass-styling-mobile](https://user-images.githubusercontent.com/3084059/32988152-b6a8cf36-ccb2-11e7-99c6-70e6d3b82a45.png)
